### PR TITLE
feat: create gateway (edge) service, with graphql support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -73,6 +73,29 @@ steps:
         exclude:
           - pull_request
 
+  - name: docker-build-dev-edge-service
+    image: plugins/docker
+    settings:
+      dockerfile: edge-service/Dockerfile
+      context: ./edge-service/
+      storage_driver: vfs
+      username:
+        from_secret: DOCKER_USERNAME
+      password:
+        from_secret: DOCKER_PASSWORD
+      repo: docker-registry.ujar.org/ujar/micro-k8s-bookingdb-edge-service
+      registry: docker-registry.ujar.org
+      tags :
+        - latest
+    when:
+      branch:
+        include:
+          - main
+          - develop
+          - feature/*
+      event:
+        exclude:
+          - pull_request
 
   - name: docker-build-dev-dashboard-service
     image: plugins/docker

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This project creates a complete microservice demo system in Docker
 containers. The services are implemented in Java using Spring and Spring Cloud.
 
 It uses three microservices:
-- `init-container-service` to ran the database migrations on deploy.
+- `init-container-service` to run the database migrations on deploy.
+- `edge-service` - provide API gateway, which supports reactive http communications to underlying service (dashboard), simple GraphQL interface to fetch countries, cities & hotels data.
 - `importer-service` to handle Booking.com API descriptive data (countries, cities, hotels lists).
 - `dashboard-service` provides API for frontend/end user interactions.
 

--- a/dashboard-service/src/main/resources/application-local.yml
+++ b/dashboard-service/src/main/resources/application-local.yml
@@ -13,6 +13,12 @@ spring :
       enabled : true
     livereload :
       enabled : true
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type: INFO
+
 management :
   endpoints :
     enabled-by-default : true

--- a/edge-service/Dockerfile
+++ b/edge-service/Dockerfile
@@ -1,0 +1,7 @@
+FROM docker-registry.ujar.org/ujar/openjdk:17.0.2-slim
+
+WORKDIR /app
+
+COPY ./target/*.jar /app/app.jar
+ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -Duser.timezone=UTC -jar /app/app.jar"]
+EXPOSE 8080

--- a/edge-service/pom.xml
+++ b/edge-service/pom.xml
@@ -2,43 +2,16 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.ujar.micro.k8s.bookingdb</groupId>
-    <artifactId>bookingdb</artifactId>
+    <artifactId>edge-service</artifactId>
     <version>0.8.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
-    <name>micro-k8s-bookingdb</name>
-    <description>Sample Spring Boot application that uses some features provided by Spring Cloud, deployed on Kubernetes</description>
-    <licenses>
-        <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-    <organization>
-        <name>uJar Bootcamp</name>
-        <url>https://www.ujar.org</url>
-    </organization>
-    <developers>
-        <developer>
-            <id>1</id>
-            <name>Dima Denysenko</name>
-            <email>coding@dimdnk.com</email>
-            <roles>
-                <role>Developer</role>
-            </roles>
-        </developer>
-    </developers>
-
-    <scm>
-        <connection>scm:git:https://github.com/ujar-org/micro-k8s-bookingdb.git</connection>
-        <tag>HEAD</tag>
-    </scm>
+    <name>edge-service</name>
+    <description>Update database structure using Liquibase</description>
 
     <parent>
-        <groupId>org.ujar.parent</groupId>
-        <artifactId>ujar-parent-pom</artifactId>
+        <groupId>org.ujar.micro.k8s.bookingdb</groupId>
+        <artifactId>bookingdb</artifactId>
         <version>0.8.0-SNAPSHOT</version>
     </parent>
 
@@ -46,47 +19,85 @@
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <start-class>org.ujar.micro.k8s.bookingdb.edge.EdgeServiceApplication</start-class>
     </properties>
 
-    <modules>
-        <module>edge-service</module>
-        <module>bookingdb-support</module>
-        <module>dashboard-service</module>
-        <module>init-container-service</module>
-        <module>importer-service</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ujar.boot</groupId>
+            <artifactId>ujar-boot-starter-logbook</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-graphql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.graphql</groupId>
+            <artifactId>spring-graphql-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                        <release>${java.version}</release>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-resources-plugin</artifactId>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-checkstyle-plugin</artifactId>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
-                    <compilerArgument>-Xlint:deprecation</compilerArgument>
+                    <mainClass>${start-class}</mainClass>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/EdgeServiceApplication.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/EdgeServiceApplication.java
@@ -1,0 +1,11 @@
+package org.ujar.micro.k8s.bookingdb.edge;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class EdgeServiceApplication {
+  public static void main(String[] args) {
+    SpringApplication.run(EdgeServiceApplication.class, args);
+  }
+}

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/config/ApplicationConfig.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/config/ApplicationConfig.java
@@ -1,16 +1,9 @@
 package org.ujar.micro.k8s.bookingdb.edge.config;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 @EnableConfigurationProperties(ServicesProperties.class)
 class ApplicationConfig {
-
-  @Bean
-  WebClient webClient(WebClient.Builder builder) {
-    return builder.build();
-  }
 }

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/config/ApplicationConfig.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/config/ApplicationConfig.java
@@ -1,0 +1,16 @@
+package org.ujar.micro.k8s.bookingdb.edge.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+@EnableConfigurationProperties(ServicesProperties.class)
+class ApplicationConfig {
+
+  @Bean
+  WebClient webClient(WebClient.Builder builder) {
+    return builder.build();
+  }
+}

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/config/GatewayConfig.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/config/GatewayConfig.java
@@ -1,0 +1,28 @@
+package org.ujar.micro.k8s.bookingdb.edge.config;
+
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+
+@Configuration
+class GatewayConfig {
+
+  @Bean
+  RouteLocator gateway(RouteLocatorBuilder rlb, ServicesProperties properties) {
+    return
+        rlb
+            .routes()
+            .route(rs ->
+                rs.path("/")
+                    .filters(fs -> fs
+                        .setPath("/dashboard/")
+                        .addResponseHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+                        .retry(3)
+                    )
+                    .uri(properties.dashboardService())
+            )
+            .build();
+  }
+}

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/config/ServicesProperties.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/config/ServicesProperties.java
@@ -8,8 +8,4 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 @ConfigurationProperties(prefix = "ujar.services")
 public record ServicesProperties(String dashboardService) {
-
-  public String dashboardService(String uri) {
-    return dashboardService + uri;
-  }
 }

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/config/ServicesProperties.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/config/ServicesProperties.java
@@ -1,0 +1,15 @@
+package org.ujar.micro.k8s.bookingdb.edge.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.validation.annotation.Validated;
+
+@ConstructorBinding
+@Validated
+@ConfigurationProperties(prefix = "ujar.services")
+public record ServicesProperties(String dashboardService) {
+
+  public String dashboardService(String uri) {
+    return dashboardService + uri;
+  }
+}

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/model/City.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/model/City.java
@@ -1,0 +1,6 @@
+package org.ujar.micro.k8s.bookingdb.edge.model;
+
+
+public record City(Long id, String name, Long cityId) {
+
+}

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/model/CityPage.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/model/CityPage.java
@@ -1,0 +1,12 @@
+package org.ujar.micro.k8s.bookingdb.edge.model;
+
+import java.util.List;
+
+public record CityPage(List<City> content,
+                       Integer totalPages,
+                       Integer totalElements,
+                       Integer size,
+                       Integer number,
+                       Pageable pageable) {
+
+}

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/model/Country.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/model/Country.java
@@ -1,0 +1,4 @@
+package org.ujar.micro.k8s.bookingdb.edge.model;
+
+public record Country(Long id, String name, String country) {
+}

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/model/CountryPage.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/model/CountryPage.java
@@ -1,0 +1,12 @@
+package org.ujar.micro.k8s.bookingdb.edge.model;
+
+import java.util.List;
+
+public record CountryPage(List<Country> content,
+                          Integer totalPages,
+                          Integer totalElements,
+                          Integer size,
+                          Integer number,
+                          Pageable pageable) {
+
+}

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/model/Hotel.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/model/Hotel.java
@@ -1,0 +1,5 @@
+package org.ujar.micro.k8s.bookingdb.edge.model;
+
+public record Hotel(Long id, Long hotelId) {
+
+}

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/model/HotelPage.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/model/HotelPage.java
@@ -1,0 +1,12 @@
+package org.ujar.micro.k8s.bookingdb.edge.model;
+
+import java.util.List;
+
+public record HotelPage(List<Hotel> content,
+                        Integer totalPages,
+                        Integer totalElements,
+                        Integer size,
+                        Integer number,
+                        Pageable pageable) {
+
+}

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/model/Pageable.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/model/Pageable.java
@@ -1,0 +1,6 @@
+package org.ujar.micro.k8s.bookingdb.edge.model;
+
+public record Pageable(Integer offset,
+                       Integer pageNumber,
+                       Integer pageSize) {
+}

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/service/DashboardService.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/service/DashboardService.java
@@ -1,6 +1,5 @@
 package org.ujar.micro.k8s.bookingdb.edge.service;
 
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/service/DashboardService.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/service/DashboardService.java
@@ -1,5 +1,6 @@
 package org.ujar.micro.k8s.bookingdb.edge.service;
 
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -15,25 +16,54 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class DashboardService {
   private final ServicesProperties properties;
-  private final WebClient httpClient;
 
-  public Mono<CountryPage> countries() {
-    return httpClient.get()
-        .uri(properties.dashboardService("/api/v1/countries"))
+  public Mono<CountryPage> countries(Integer page, Integer size) {
+    if (size == null) {
+      size = 10;
+    }
+    var pageSize = size;
+    return WebClient.builder()
+        .baseUrl(properties.dashboardService()).build().get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/api/v1/countries")
+            .queryParam("page", page)
+            .queryParam("size", pageSize)
+            .build()
+        )
         .retrieve()
         .bodyToMono(CountryPage.class);
   }
 
-  public Mono<CityPage> cities() {
-    return httpClient.get()
-        .uri(properties.dashboardService("/api/v1/cities"))
+  public Mono<CityPage> cities(Integer page, Integer size) {
+    if (size == null) {
+      size = 10;
+    }
+    var pageSize = size;
+    return WebClient.builder()
+        .baseUrl(properties.dashboardService()).build().get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/api/v1/cities")
+            .queryParam("page", page)
+            .queryParam("size", pageSize)
+            .build()
+        )
         .retrieve()
         .bodyToMono(CityPage.class);
   }
 
-  public Mono<HotelPage> hotels() {
-    return httpClient.get()
-        .uri(properties.dashboardService("/api/v1/hotels"))
+  public Mono<HotelPage> hotels(Integer page, Integer size) {
+    if (size == null) {
+      size = 10;
+    }
+    var pageSize = size;
+    return WebClient.builder()
+        .baseUrl(properties.dashboardService()).build().get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/api/v1/hotels")
+            .queryParam("page", page)
+            .queryParam("size", pageSize)
+            .build()
+        )
         .retrieve()
         .bodyToMono(HotelPage.class);
   }

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/service/DashboardService.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/service/DashboardService.java
@@ -1,0 +1,40 @@
+package org.ujar.micro.k8s.bookingdb.edge.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.ujar.micro.k8s.bookingdb.edge.config.ServicesProperties;
+import org.ujar.micro.k8s.bookingdb.edge.model.CityPage;
+import org.ujar.micro.k8s.bookingdb.edge.model.CountryPage;
+import org.ujar.micro.k8s.bookingdb.edge.model.HotelPage;
+import reactor.core.publisher.Mono;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class DashboardService {
+  private final ServicesProperties properties;
+  private final WebClient httpClient;
+
+  public Mono<CountryPage> countries() {
+    return httpClient.get()
+        .uri(properties.dashboardService("/api/v1/countries"))
+        .retrieve()
+        .bodyToMono(CountryPage.class);
+  }
+
+  public Mono<CityPage> cities() {
+    return httpClient.get()
+        .uri(properties.dashboardService("/api/v1/cities"))
+        .retrieve()
+        .bodyToMono(CityPage.class);
+  }
+
+  public Mono<HotelPage> hotels() {
+    return httpClient.get()
+        .uri(properties.dashboardService("/api/v1/hotels"))
+        .retrieve()
+        .bodyToMono(HotelPage.class);
+  }
+}

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/web/DashboardController.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/web/DashboardController.java
@@ -1,0 +1,32 @@
+package org.ujar.micro.k8s.bookingdb.edge.web;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+import org.ujar.micro.k8s.bookingdb.edge.model.CityPage;
+import org.ujar.micro.k8s.bookingdb.edge.model.CountryPage;
+import org.ujar.micro.k8s.bookingdb.edge.model.HotelPage;
+import org.ujar.micro.k8s.bookingdb.edge.service.DashboardService;
+import reactor.core.publisher.Mono;
+
+@Controller
+@RequiredArgsConstructor
+public class DashboardController {
+
+  private final DashboardService service;
+
+  @QueryMapping
+  Mono<CountryPage> countries() {
+    return service.countries();
+  }
+
+  @QueryMapping
+  Mono<CityPage> cities() {
+    return service.cities();
+  }
+
+  @QueryMapping
+  Mono<HotelPage> hotels() {
+    return service.hotels();
+  }
+}

--- a/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/web/DashboardController.java
+++ b/edge-service/src/main/java/org/ujar/micro/k8s/bookingdb/edge/web/DashboardController.java
@@ -1,6 +1,8 @@
 package org.ujar.micro.k8s.bookingdb.edge.web;
 
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
 import org.ujar.micro.k8s.bookingdb.edge.model.CityPage;
@@ -16,17 +18,17 @@ public class DashboardController {
   private final DashboardService service;
 
   @QueryMapping
-  Mono<CountryPage> countries() {
-    return service.countries();
+  Mono<CountryPage> countries(@Argument @NonNull Integer page, @Argument Integer size) {
+    return service.countries(page, size);
   }
 
   @QueryMapping
-  Mono<CityPage> cities() {
-    return service.cities();
+  Mono<CityPage> cities(@Argument @NonNull Integer page, @Argument Integer size) {
+    return service.cities(page, size);
   }
 
   @QueryMapping
-  Mono<HotelPage> hotels() {
-    return service.hotels();
+  Mono<HotelPage> hotels(@Argument @NonNull Integer page, @Argument Integer size) {
+    return service.hotels(page, size);
   }
 }

--- a/edge-service/src/main/resources/application-local.yml
+++ b/edge-service/src/main/resources/application-local.yml
@@ -1,0 +1,19 @@
+spring :
+  application :
+    name : edge-service
+  lifecycle :
+    timeout-per-shutdown-phase : ${TIMEOUT_PER_SHUTDOWN:20s}
+  graphql :
+    graphiql :
+      enabled : true
+
+management :
+  endpoints :
+    enabled-by-default : true
+
+server:
+  port : 2999
+
+ujar:
+  services:
+    dashboard-service: http://localhost:3000

--- a/edge-service/src/main/resources/application.yml
+++ b/edge-service/src/main/resources/application.yml
@@ -1,0 +1,74 @@
+git :
+  commit : '@git.commit.id@'
+  build_time : '@git.build.time@'
+
+info :
+  app :
+    name : '@project.name@'
+    description : '@project.description@'
+    version : '@project.version@'
+    git_commit : ${git.commit}
+    build_time : ${git.build_time}
+
+spring :
+  application :
+    name : edge-service
+  lifecycle :
+    timeout-per-shutdown-phase : ${TIMEOUT_PER_SHUTDOWN:20s}
+  graphql :
+    graphiql :
+      enabled : true
+
+logging :
+  level :
+    ROOT : ${LOGGING_LEVEL_ROOT:INFO}
+    org.zalando.logbook.Logbook : TRACE
+
+logbook :
+  filter :
+    enabled : true
+  format :
+    style : json
+  obfuscate :
+    headers :
+      - Authorization
+      - X-Secret
+    parameters :
+      - access_token
+      - password
+  minimum-status : ${MINIMUM_STATUS_LOG_BODY:400}
+
+server :
+  port : ${SERVER_PORT:8080}
+  shutdown : graceful
+
+management :
+  health :
+    livenessstate :
+      enabled : true
+    readinessstate :
+      enabled : true
+  info :
+    env :
+      enabled : true
+  server :
+    add-application-context-header : true
+  endpoints :
+    enabled-by-default : false
+    web :
+      exposure :
+        include : health, prometheus, info
+  endpoint :
+    health :
+      enabled : true
+      show-details : always
+      probes :
+        enabled : true
+    prometheus :
+      enabled : true
+    info :
+      enabled : true
+
+ujar:
+  services:
+    dashboard-service: ${DASHBOARD_SERVICE_URL:http://dashboard-service}

--- a/edge-service/src/main/resources/banner.txt
+++ b/edge-service/src/main/resources/banner.txt
@@ -1,0 +1,8 @@
+${AnsiColor.GREEN}              | |               
+${AnsiColor.GREEN}  _   _       | |   __ _   _ __ 
+${AnsiColor.GREEN} | | | |  _   | |  / _` | | '__|
+${AnsiColor.GREEN} | |_| | | |__| | | (_| | | |   
+${AnsiColor.GREEN}  \__,_|  \____/   \__,_| |_|   
+${AnsiColor.BLUE} ===============================
+${AnsiColor.BLUE} Gateway Service
+${AnsiColor.BLUE} ===============================

--- a/edge-service/src/main/resources/graphql/schema.graphqls
+++ b/edge-service/src/main/resources/graphql/schema.graphqls
@@ -1,0 +1,57 @@
+type Query {
+    countries: CountryPageContent
+    cities: CityPageContent
+    hotels: CityPageContent
+}
+
+type Pageable {
+    offset: Int,
+    pageNumber: Int,
+    pageSize: Int,
+}
+
+type CountryPageContent {
+    pageable: Pageable
+    content: [Country]
+    totalPages: Int
+    totalElements: Int
+    size: Int
+    number: Int
+}
+
+type CityPageContent {
+    pageable: Pageable
+    content: [City]
+    totalPages: Int
+    totalElements: Int
+    size: Int
+    number: Int
+}
+
+type HotelPageContent {
+    pageable: Pageable
+    content: [Hotel]
+    totalPages: Int
+    totalElements: Int
+    size: Int
+    number: Int
+}
+
+
+type Country {
+    id: ID
+    name : String
+    country : String
+}
+
+type City {
+    id: ID
+    name : String
+    cityId : Int
+}
+
+type Hotel {
+    id: ID
+    name : String
+    hotelId : Int
+}

--- a/edge-service/src/main/resources/graphql/schema.graphqls
+++ b/edge-service/src/main/resources/graphql/schema.graphqls
@@ -1,7 +1,7 @@
 type Query {
-    countries: CountryPageContent
-    cities: CityPageContent
-    hotels: CityPageContent
+    countries(page: Int, size: Int): CountryPageContent
+    cities(page: Int, size: Int): CityPageContent
+    hotels(page: Int, size: Int): CityPageContent
 }
 
 type Pageable {

--- a/edge-service/src/main/resources/logback.xml
+++ b/edge-service/src/main/resources/logback.xml
@@ -1,0 +1,55 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml" />
+
+    <springProperty name="feature" source="spring.application.name"/>
+    <springProperty name="application_name" source="spring.application.name"/>
+
+    <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${application_name} %clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr([%X{transactionId},%X{traceId:-},%X{spanId:-}]){blue}[%thread] %clr(%-5level) %clr(%logger{36}){magenta} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CONSOLE_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp>
+                    <fieldName>log_timestamp</fieldName>
+                    <timeZone>UTC</timeZone>
+                </timestamp>
+                <pattern>
+                    <pattern>
+                        {
+                        "env": "${ENV}",
+                        "feature": "${feature}",
+                        "level": "%level",
+                        "thread": "%thread",
+                        "logger": "%logger",
+                        "class": "%class",
+                        "message": "%message",
+                        "method": "%method",
+                        "line": "%line",
+                        "hostname": "${HOSTNAME}",
+                        "trace_id":"%X{dd.trace_id:-0}",
+                        "span_id": "%X{dd.span_id:-0}",
+                        "data_privacy":"%X{private:-0}"
+                        }
+                    </pattern>
+                </pattern>
+                <stackTrace>
+                    <fieldName>exception</fieldName>
+                    <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                        <maxDepthPerThrowable>30</maxDepthPerThrowable>
+                        <maxLength>1024</maxLength>
+                        <rootCauseFirst>true</rootCauseFirst>
+                    </throwableConverter>
+                </stackTrace>
+            </providers>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="${LOGBACK_APPENDER:-CONSOLE}" />
+    </root>
+</configuration>

--- a/edge-service/src/test/java/org/ujar/micro/k8s/bookingdb/edge/EdgeServiceApplicationTest.java
+++ b/edge-service/src/test/java/org/ujar/micro/k8s/bookingdb/edge/EdgeServiceApplicationTest.java
@@ -1,0 +1,18 @@
+package org.ujar.micro.k8s.bookingdb.edge;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class EdgeServiceApplicationTest {
+
+  @Test
+  void contextLoad() {
+    Assertions.assertDoesNotThrow(this::doNotThrowException);
+  }
+
+  private void doNotThrowException() {
+    // This method will never throw exception
+  }
+}

--- a/edge-service/src/test/resources/application.yml
+++ b/edge-service/src/test/resources/application.yml
@@ -1,0 +1,7 @@
+spring :
+  application :
+    name : edge-service
+
+ujar:
+  services:
+    dashboard-service: http://dashboard-service

--- a/init-container-service/src/main/resources/application-local.yml
+++ b/init-container-service/src/main/resources/application-local.yml
@@ -18,4 +18,4 @@ management :
     enabled-by-default : true
 
 server:
-  port : 2999
+  port : 2998

--- a/k8s/edge/configmap.yaml
+++ b/k8s/edge/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion : v1
+kind : ConfigMap
+metadata :
+  name : edge-service
+data :
+  dashboard-service-url : http://dashboard-service

--- a/k8s/edge/deployment.yaml
+++ b/k8s/edge/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion : apps/v1
+kind : Deployment
+metadata :
+  name : edge-service
+  labels :
+    app : edge-service
+spec :
+  replicas : 1
+  strategy :
+    type : RollingUpdate
+  selector :
+    matchLabels :
+      app : edge-service
+  template :
+    metadata :
+      labels :
+        app : edge-service
+    spec :
+      containers :
+        - name : edge-service
+          image : docker-registry.ujar.org/ujar/micro-k8s-bookingdb-edge-service:latest
+          imagePullPolicy: Always
+          ports :
+            - containerPort : 8080
+          env :
+            - name : DASHBOARD_SERVICE_URL
+              valueFrom :
+                configMapKeyRef :
+                  name : edge-service
+                  key : dashboard-service-url
+          resources :
+            requests :
+              cpu : "0.2"
+              memory : 300Mi
+            limits :
+              cpu : "1.0"
+              memory : 300Mi
+          readinessProbe :
+            httpGet :
+              port : 8080
+              path: /actuator/health/readiness
+            initialDelaySeconds : 50
+            timeoutSeconds : 2
+            periodSeconds : 20
+            failureThreshold : 5
+          livenessProbe :
+            httpGet:
+              port: 8080
+              path: /actuator/health/liveness
+            initialDelaySeconds : 50
+            timeoutSeconds : 2
+            periodSeconds : 20
+            failureThreshold : 5
+          startupProbe:
+            httpGet:
+              port: 8080
+              path: /actuator/health/readiness
+            initialDelaySeconds: 5
+      serviceAccountName : api-service-account
+---
+apiVersion : v1
+kind : Service
+metadata :
+  name : edge-service
+  labels :
+    app : edge-service
+spec :
+  ports :
+    - port : 8080
+      targetPort : 8080
+      protocol : TCP
+  selector :
+    app : edge-service

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -39,3 +39,10 @@ spec :
                 name : grafana-np
                 port :
                   number : 3000
+          - path : /proxy(/|$)(.*)
+            pathType : Prefix
+            backend :
+              service :
+                name : edge-service
+                port :
+                  number : 8080

--- a/scripts/delete-apps.sh
+++ b/scripts/delete-apps.sh
@@ -12,6 +12,11 @@ kubectl delete -n $K8S_NAMESPACE service importer-service
 kubectl delete -n $K8S_NAMESPACE configmap importer-service
 kubectl delete -n $K8S_NAMESPACE secret importer-service
 
+kubectl delete -n $K8S_NAMESPACE deployment edge-service
+kubectl delete -n $K8S_NAMESPACE service edge-service
+kubectl delete -n $K8S_NAMESPACE configmap edge-service
+kubectl delete -n $K8S_NAMESPACE secret edge-service
+
 kubectl delete -n $K8S_NAMESPACE deployment dashboard-service
 kubectl delete -n $K8S_NAMESPACE service dashboard-service
 kubectl delete -n $K8S_NAMESPACE configmap dashboard-service

--- a/scripts/install-apps.sh
+++ b/scripts/install-apps.sh
@@ -14,6 +14,10 @@ kubectl config use-context $CLUSTER_NAME
 kubectl apply -n $K8S_NAMESPACE -f init-container/configmap.yaml
 kubectl apply -n $K8S_NAMESPACE -f init-container/secret.yaml
 kubectl apply -n $K8S_NAMESPACE -f init-container/deployment.yaml
+
+kubectl apply -n $K8S_NAMESPACE -f edge/configmap.yaml
+kubectl apply -n $K8S_NAMESPACE -f edge/deployment.yaml
+
 kubectl apply -n $K8S_NAMESPACE -f dashboard/configmap.yaml
 kubectl apply -n $K8S_NAMESPACE -f dashboard/secret.yaml
 kubectl apply -n $K8S_NAMESPACE -f dashboard/deployment.yaml


### PR DESCRIPTION
Provide the ability to use API gateway, which supports reactive http communications to underlying service (dashboard), simple GraphQL interface to fetch countries, cities & hotels data.